### PR TITLE
fix PHP redirect to HTTPS; fix warning

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,9 +34,9 @@ log_debug("index", "Starting index.php");
 /*
 	Enforce HTTPS
 */
-if (!$_SERVER["HTTPS"])
+if (empty($_SERVER["HTTPS"]))
 {
-	header("Location: https://". $_SERVER["SERVER_NAME"] ."/".  $_SERVER['PHP_SELF'] );
+	header("Location: https://". $_SERVER["HTTP_HOST"] .$_SERVER["PHP_SELF"]);
 	exit(0);
 }
 


### PR DESCRIPTION
- Fix broken redirect under nginx/php-fpm;
- Fix the following PHP warning:
  
  PHP message: PHP Notice:  Undefined index: HTTPS in amberdms/index.php
